### PR TITLE
Re-order Dockerfile + improve Gitlab CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*.sqlite3
+.gitlab-ci.yml
+.python-version
+*.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,5 +27,8 @@ deploy:
     - docker push $DOCKER_HUB_IMAGE
     - apk add --update --no-cache curl
     - curl -X GET "$WEBHOOK_URL"
+  environment:
+    name: production
+    url: https://fakenewsdetector.augendre.info
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,8 @@ build-master:
   stage: build
   script:
     - docker pull $CI_REGISTRY_IMAGE:latest || true
-    - docker build --cache-from $CI_REGISTRY_IMAGE:latest -t $CONTAINER_TEST_IMAGE -t $CI_REGISTRY_IMAGE:latest .
+    - docker pull $CONTAINER_TEST_IMAGE || true
+    - docker build --cache-from $CI_REGISTRY_IMAGE:latest --cache-from $CONTAINER_TEST_IMAGE -t $CONTAINER_TEST_IMAGE -t $CI_REGISTRY_IMAGE:latest .
     - docker push $CONTAINER_TEST_IMAGE
     - docker push $CI_REGISTRY_IMAGE:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ COPY Pipfile Pipfile.lock ./
 RUN pipenv install && apk del .build-deps
 RUN pipenv run python -m spacy download fr
 
-COPY . ./
+COPY bash/ ./bash/
+COPY manage.py healthcheck.py ./
+COPY fake_news_detector_api/ ./fake_news_detector_api/
+COPY api/ ./api/
 
 CMD ["sh", "bash/run-prod.sh"]
 


### PR DESCRIPTION
- Re-order Dockerfile to have a smarter order for code files and reduce the number of files included (don't change docker image when `.gitlab-ci.yml` is edited for example)
- Add environment key to gitlab CI to leverage environments in Gitlab
- Pull another image as potential cache source for building the image as the build may be quite long compared to pulling two images.