### PR TITLE
Improve log when healthcheck fails by adding the real exception message

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -55,8 +55,8 @@ def ping_view(request):
         return JsonResponse({
             'status': 'alive'
         })
-    except Exception:
-        logger.critical("Error while trying to access DB when responding to healthcheck")
+    except Exception as e:
+        logger.critical(f"Error while trying to access DB when responding to healthcheck: {e}")
         return JsonResponse({
             'status': 'dead'
         })

--- a/fake_news_detector_api/settings.py
+++ b/fake_news_detector_api/settings.py
@@ -120,6 +120,11 @@ LOG_LEVEL = 'DEBUG' if DEBUG else 'INFO'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+    },
     'formatters': {
         'verbose': {
             'format': '[%(asctime)s] [%(process)d] [%(levelname)s] %(module)s - %(message)s'
@@ -132,6 +137,7 @@ LOGGING = {
         },
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
         }
     },


### PR DESCRIPTION
We currently miss the real exception message in the logs, this PR fixes it.
Also disable mail to admin when `DEBUG` is `True`